### PR TITLE
Small fixes / cleanup of imports

### DIFF
--- a/mocpy/py23_compat.py
+++ b/mocpy/py23_compat.py
@@ -2,22 +2,38 @@
 py23_compat.py
 
 Python 2 / 3 compatibility layer.
-
 """
-try:
+import sys
+
+__all__ = [
+    'int', 'range', 'set', 'urlencode', 'BytesIO',
+]
+
+PY2 = (sys.version_info.major == 2)
+
+if PY2:
     int = long
     range = xrange
-except NameError:
+else:
     int = int
     range = range
 
-try:
+if PY2:
     from sets import Set as set
-except ImportError:
-    pass
+else:
+    set = set
 
-try:
+if PY2:
     from urllib import urlencode
-except ImportError:
+else:
     from urllib.parse import urlencode
 
+# https://pythonhosted.org/six/#six.BytesIO
+if PY2:
+    import StringIO
+
+    BytesIO = StringIO.StringIO
+else:
+    import io
+
+    BytesIO = io.BytesIO

--- a/mocpy/utils.py
+++ b/mocpy/utils.py
@@ -1,13 +1,5 @@
 import numpy as np
 
-def radec2thetaphi(ra, dec):
-    """
-    convert equatorial ra, dec in degrees
-    to polar theta, phi in radians
-
-    """
-    return np.pi/2 - np.radians(dec), np.radians(ra)
-
 
 def uniq2orderipix(uniq):
     """


### PR DESCRIPTION
This PR does a few small fixes / cleanup:

- Move matplotlib imports into plot methods, so that using MOC for computation doesn't import matplotlib (especially not matplotlib.pyplot which starts the plotting GUI thread)
- Remove `utils.radec2thetaphi` and replace use of `astropy_healpix.healpy.ang2pix` by `HEALPix` class
- Remove an import of `six.BytesIO` and instead declare `BytesIO` in `py23_compat.py` to avoid the dependency (which isn't declared in `setup.py`)

