### PR TITLE
checking notebooks with travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,16 @@ install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
-  - conda config --add channels conda-forge
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pytest numpy matplotlib astropy astropy-healpix six requests
+  - conda env create -q -n test-environment python=$TRAVIS_PYTHON_VERSION -f environment.yml
   - source activate test-environment
 
 script:
 #  - python setup.py install
   - python -m pytest -v mocpy
+# install mocpy in the conda env so that the notebooks
+# can import it
+  - pip install .
+  - python test_notebooks.py

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,19 @@
+name: travis_anaconda_jupyter
+channels:
+- defaults
+- conda-forge
+dependencies:
+- astropy
+- astropy-healpix
+- astroquery
+- jupyter
+- matplotlib
+- nbconvert
+- nbformat
+- numpy
+- pytest
+- requests
+- six
+
+
+

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,3 @@ dependencies:
 - pytest
 - requests
 - six
-
-
-

--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -4,12 +4,6 @@ from nbconvert.preprocessors import ExecutePreprocessor
 
 from glob import glob
 
-class bcolors:
-    OKGREEN = '\033[92m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-
-
 notebook_filenames_l = glob("notebooks/*.ipynb")
 
 for notebook_filename in notebook_filenames_l:
@@ -20,8 +14,8 @@ for notebook_filename in notebook_filenames_l:
         try:
             ep.preprocess(nb, {'metadata': {'path': 'notebooks/'}})
         except CellExecutionError as e:
-            print(("{0} " + bcolors.FAIL + "[FAILED]" + bcolors.ENDC + "\n{1}").format(notebook_filename, e))
+            print("{0} [FAILED]\n{1}".format(notebook_filename, e))
             # exit with error status code
             exit(1)
-        print(("{0} " + bcolors.OKGREEN + "[PASSED]" + bcolors.ENDC).format(notebook_filename))
+        print("{0} [PASSED]".format(notebook_filename))
 

--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -1,0 +1,27 @@
+import nbformat
+from nbconvert.preprocessors import CellExecutionError
+from nbconvert.preprocessors import ExecutePreprocessor
+
+from glob import glob
+
+class bcolors:
+    OKGREEN = '\033[92m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+
+
+notebook_filenames_l = glob("notebooks/*.ipynb")
+
+for notebook_filename in notebook_filenames_l:
+    with open(notebook_filename) as f:
+        print("Executing notebook : {0}".format(notebook_filename))
+        nb = nbformat.read(f, as_version=4)
+        ep = ExecutePreprocessor(timeout=1000, kernel_name='python3')
+        try:
+            ep.preprocess(nb, {'metadata': {'path': 'notebooks/'}})
+        except CellExecutionError as e:
+            print(("{0} " + bcolors.FAIL + "[FAILED]" + bcolors.ENDC + "\n{1}").format(notebook_filename, e))
+            # exit with error status code
+            exit(1)
+        print(("{0} " + bcolors.OKGREEN + "[PASSED]" + bcolors.ENDC).format(notebook_filename))
+


### PR DESCRIPTION
This PR references the issue #20 

We would like travis-ci to run our notebooks and fail if one of them give an error. Notebooks must be run on the master source code of mocpy.
Thanks to @cdeil idea, we use a test_notebooks.py script located at the repo's root and executed by travis (see .travis.yml). This script globs all the ipynb files (notebooks) in the notebooks/ folder.
The found notebooks are then run following what's explained in http://nbconvert.readthedocs.io/en/latest/execute_api.html .
If an error occurs during one notebook execution, the script is exited with an error status code which interrupts travis-ci.