### PR TITLE
fix binder MOCPy import error

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,14 @@
+name: mocpy-dev
+
+channels:
+- defaults
+- conda-forge
+
+dependencies:
+- astropy
+- astropy-healpix
+- astroquery
+- matplotlib
+- numpy
+- requests
+- six

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Install the MOCPy version from the remote repo
+pip install .
+
+


### PR DESCRIPTION
After the binder's image is built we pip install the MOCPy version of the repo.
This is done in a postBuild bash script that is executed by mybinder when it finishes the building of the env.

See https://mybinder.readthedocs.io/en/latest/using.html#postbuild