### PR TITLE
Serialize to str and from_str

### DIFF
--- a/docs/examples/polygon_coverage.py
+++ b/docs/examples/polygon_coverage.py
@@ -28,7 +28,7 @@ skycoord = SkyCoord(vertices, unit="deg", frame="icrs")
 # A point that we say it belongs to the inside of the MOC
 inside = SkyCoord(ra=10, dec=5, unit="deg", frame="icrs")
 moc = MOC.from_polygon_skycoord(skycoord, max_depth=9, inside=inside)
-moc.write('polygon_moc.fits', format='fits')
+moc.write('polygon_moc.fits', format='fits', overwrite=True)
 # Plot the MOC using matplotlib
 import matplotlib.pyplot as plt
 fig = plt.figure(111, figsize=(10, 10))

--- a/environment.yml
+++ b/environment.yml
@@ -18,3 +18,4 @@ dependencies:
   - numpydoc
   - networkx
   - spherical_geometry
+  - lark-parser

--- a/mocpy/abstract_moc.py
+++ b/mocpy/abstract_moc.py
@@ -318,6 +318,8 @@ class AbstractMOC:
         # Import lark parser when from_str is called
         # at least one time
         from lark import Lark, Transformer
+        class ParsingException(Exception):
+            pass
 
         class TreeToJson(Transformer):
             def value(self, items):
@@ -365,7 +367,11 @@ class AbstractMOC:
                 %import common.INT
                 """, start='value')
 
-        tree = AbstractMOC.LARK_PARSER_STR.parse(value)
+        try:
+            tree = AbstractMOC.LARK_PARSER_STR.parse(value)
+        except Exception as err:
+            raise ParsingException("Could not parse {0}. \n Check the grammar section 2.3.2 of http://ivoa.net/documents/MOC/20190215/WD-MOC-1.1-20190215.pdf to see the correct syntax for writing a MOC from a str".format(value))
+
         moc_json = TreeToJson().transform(tree)
 
         return cls.from_json(moc_json)

--- a/mocpy/abstract_moc.py
+++ b/mocpy/abstract_moc.py
@@ -297,7 +297,7 @@ class AbstractMOC:
         """
         Create a MOC from a str.
         
-        This grammar is expressed is the `MOC IVOA <http://ivoa.net/documents/MOC/20190215/WD-MOC-1.1-20190215.pdf>`
+        This grammar is expressed is the `MOC IVOA <http://ivoa.net/documents/MOC/20190215/WD-MOC-1.1-20190215.pdf>`__
         specification at section 2.3.2.
 
         Parameters

--- a/mocpy/tests/test_moc.py
+++ b/mocpy/tests/test_moc.py
@@ -92,6 +92,16 @@ def test_moc_serialize_and_from_json(moc_from_fits_image):
     moc2 = MOC.from_json(ipix_d)
     assert moc_from_fits_image == moc2
 
+@pytest.mark.parametrize("moc, expected", [
+    (MOC.from_json({'5': [8, 9, 10, 42, 43, 44, 45, 54, 46], '6':[4500], '7':[], '8':[45]}),
+    '5/8-10,42-46,54 6/4500 8/45'),
+    (MOC.from_json({}), ''),
+    (MOC.from_json({'29': [101]}), '29/101'),
+    (MOC.from_json({'0': [1, 0, 9]}), '0/0-1,9'),
+    (MOC.from_json({'0': [2, 9], '1': [9]}), '0/2,9'),
+])
+def test_serialize_to_str(moc, expected):
+    assert moc.serialize(format="str") == expected
 
 def test_moc_write_and_from_json(moc_from_fits_image):
     tmp_file = tempfile.NamedTemporaryFile()
@@ -112,7 +122,6 @@ def test_moc_write_to_fits(moc_from_fits_image):
 def test_moc_write_to_json(moc_from_fits_image):
     moc_json = moc_from_fits_image.serialize(format='json')
     assert isinstance(moc_json, dict)
-
 
 def test_moc_contains():
     order = 4

--- a/mocpy/tests/test_moc.py
+++ b/mocpy/tests/test_moc.py
@@ -92,6 +92,18 @@ def test_moc_serialize_and_from_json(moc_from_fits_image):
     moc2 = MOC.from_json(ipix_d)
     assert moc_from_fits_image == moc2
 
+@pytest.mark.parametrize("expected, moc_str", [
+    (MOC.from_json({'5': [8, 9, 10, 42, 43, 44, 45, 54, 46], '6':[4500], '7':[], '8':[45]}),
+    '5/8-10,42-46,54,8 6/4500 8/45'),
+    (MOC.from_json({}), '0/'),
+    (MOC.from_json({'29': [101]}), '29/101'),
+    (MOC.from_json({'0': [1, 0, 9]}), '0/0-1,9'),
+    (MOC.from_json({'0': [2, 9], '1': [9]}), '0/2,9'),
+    (MOC.from_json({'0': [2], '8': [8, 9, 10], '11': []}), '0/2\r ,\n 8/8-10\n 11/'),
+])
+def test_from_str(expected, moc_str):
+    assert MOC.from_str(moc_str) == expected
+
 @pytest.mark.parametrize("moc, expected", [
     (MOC.from_json({'5': [8, 9, 10, 42, 43, 44, 45, 54, 46], '6':[4500], '7':[], '8':[45]}),
     '5/8-10,42-46,54 6/4500 8/45'),

--- a/requirements/contributing.txt
+++ b/requirements/contributing.txt
@@ -10,6 +10,7 @@ astropy_healpix
 matplotlib
 networkx
 spherical_geometry
+lark-parser
 
 # Package for basic testing purposes
 pytest

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,3 +6,4 @@ networkx
 spherical_geometry
 sphinx
 numpydoc
+lark-parser

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(name='MOCPy',
         # Disable the installation of spherical-geometry as it
         # fails the appveyor tests for python 3 of astroquery. See https://github.com/astropy/astroquery/pull/1343
         # 'spherical-geometry',
+        'lark-parser', # Used in from_str for parsing the string given and create the MOC from it
     ],
     provides=['mocpy'],
     long_description="MOCPy is a Python library allowing easy creation \


### PR DESCRIPTION
Refers to #35 
Features:
- serialize(format="str") returns a str following the grammar exposed in section 2.3.2 of the [MOC IVOA specification](http://ivoa.net/documents/MOC/20190215/WD-MOC-1.1-20190215.pdf)
- from_str takes a str and returns a MOC (use of the [lark-parser](https://github.com/lark-parser/lark) to parse the grammar)