### PR TITLE
Functions save and write now accepts pathlib.Path objects.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,8 @@
 name: test-mocpy
-on: [push]
-# Allows to run this workflow manually from the Actions tab
-workflow_dispatch:
+on: 
+  push:
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
 jobs:  
   # Linux is specific: because of manylinux, we have to use a docker file 
   test-linux64-wheels:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: test-mocpy
 on: [push]
+# Allows to run this workflow manually from the Actions tab
+workflow_dispatch:
 jobs:  
   # Linux is specific: because of manylinux, we have to use a docker file 
   test-linux64-wheels:

--- a/mocpy/moc/moc.py
+++ b/mocpy/moc/moc.py
@@ -636,7 +636,7 @@ class MOC(AbstractMOC):
 
         Parameters
         ----------
-        path : str
+        path : str or pathlib.Path
             The path to the file to save the MOC in.
         cumul_from : float
             Cumulative value from which cells will be added to the MOC
@@ -657,7 +657,7 @@ class MOC(AbstractMOC):
             The resulting MOC
         """
         intervals = mocpy.spatial_moc_from_multiordermap_fits_file(
-            path,
+            str(path),
             np.float64(cumul_from),
             np.float64(cumul_to),
             asc, 
@@ -1177,7 +1177,7 @@ class MOC(AbstractMOC):
 
         Parameters
         ----------
-        path : str
+        path : str or pathlib.Path
             The path to the file to save the MOC in.
         format : str, optional
             The format in which the MOC is saved.
@@ -1187,6 +1187,7 @@ class MOC(AbstractMOC):
             If the file already exists and you want to overwrite it, then set the  ``overwrite`` keyword. 
             Default to False.
         """
+        path = str(path)
         import os
         file_exists = os.path.isfile(path)
         
@@ -1213,13 +1214,14 @@ class MOC(AbstractMOC):
 
         Parameters
         ----------
-        path : str
+        path : str or pathlib.Path
             The path to the file to load the MOC from.
         format : str, optional
             The format from which the MOC is loaded.
             Possible formats are "fits", "ascii" or "json".
             By default, ``format`` is set to "fits".
         """
+        path = str(path)
         if format == 'fits':
             intervals = mocpy.spatial_moc_from_fits_file(path)
             return cls(IntervalSet(intervals, make_consistent=False), make_consistent=False)

--- a/mocpy/stmoc/stmoc.py
+++ b/mocpy/stmoc/stmoc.py
@@ -473,7 +473,7 @@ class STMOC(serializer.IO):
 
         Parameters
         ----------
-        path : str
+        path : str or pathlib.Path
             The path to the file to save the MOC in.
         format : str, optional
             The format in which the MOC will be serialized before being saved.
@@ -483,6 +483,7 @@ class STMOC(serializer.IO):
             If the file already exists and you want to overwrite it, then set the  ``overwrite`` keyword. 
             Default to False.
         """
+        path = str(path)
         import os
         file_exists = os.path.isfile(path)
         
@@ -509,13 +510,14 @@ class STMOC(serializer.IO):
 
         Parameters
         ----------
-        path : str
+        path : str or pathlib.Path
             The path to the file to load the MOC from.
         format : str, optional
             The format from which the MOC is loaded.
             Possible formats are "fits", "ascii" or "json".
             By default, ``format`` is set to "fits".
         """
+        path = str(path)
         stmoc = cls()
         if format == 'fits':
             mocpy.coverage_2d_from_fits_file(stmoc.__index, path)

--- a/mocpy/tmoc/tmoc.py
+++ b/mocpy/tmoc/tmoc.py
@@ -641,7 +641,7 @@ class TimeMOC(AbstractMOC):
 
         Parameters
         ----------
-        path : str
+        path : str or pathlib.Path
             The path to the file to save the MOC in.
         format : str, optional
             The format in which the MOC will be serialized before being saved.
@@ -651,6 +651,7 @@ class TimeMOC(AbstractMOC):
             If the file already exists and you want to overwrite it, then set the  ``overwrite`` keyword.
             Default to False.
         """
+        path=str(path)
         import os
         file_exists = os.path.isfile(path)
         
@@ -677,13 +678,14 @@ class TimeMOC(AbstractMOC):
 
         Parameters
         ----------
-        path : str
+        path : str or pathlib.Path
             The path to the file to load the MOC from.
         format : str, optional
             The format from which the MOC is loaded.
             Possible formats are "fits", "ascii" or "json".
             By default, ``format`` is set to "fits".
         """
+        path=str(path)
         if format == 'fits':
             intervals = mocpy.time_moc_from_fits_file(path)
             return cls(IntervalSet(intervals, make_consistent=False), make_consistent=False)


### PR DESCRIPTION
Functions save and write now accepts pathlib.Path objects for MOC, TMOC, and STMOC.

This is a quick fix, don't merge if PyO3 has a way of dealing with pathlib objects.