### PR TITLE
fix contains method for space mocs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,9 @@ bench = true
 crate-type = ["cdylib"]
 
 [dependencies]
-moc = "0.9.0"
+moc = "0.9"
 # moc = { git = 'https://github.com/cds-astro/cds-moc-rust', branch = 'main' }
-healpix = { package = "cdshealpix", version = "0.6.0" }
+healpix = { package = "cdshealpix", version = "0.6" }
 # healpix = { package = "cdshealpix", git = 'https://github.com/cds-astro/cds-healpix-rust', branch = 'master' }
 num = "0.4"
 time = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,9 @@ bench = true
 crate-type = ["cdylib"]
 
 [dependencies]
-moc = "0.7.0"
+moc = "0.9.0"
 # moc = { git = 'https://github.com/cds-astro/cds-moc-rust', branch = 'main' }
-healpix = { package = "cdshealpix", version = "0.5.5" }
+healpix = { package = "cdshealpix", version = "0.6.0" }
 # healpix = { package = "cdshealpix", git = 'https://github.com/cds-astro/cds-healpix-rust', branch = 'master' }
 num = "0.4"
 time = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "MOCPy"
-version = "0.11.0"
+version = "0.11.1"
 authors = [
   "Matthieu Baumann <baumannmatthieu0@gmail.com>", 
   "Thomas Boch <thomas.boch@astro.unistra.fr>", 

--- a/mocpy/moc/moc.py
+++ b/mocpy/moc/moc.py
@@ -224,21 +224,11 @@ class MOC(AbstractMOC):
         array : `~np.ndarray`
             A mask boolean array
         """
-        max_depth = self.max_order
-        m = np.zeros(3 << (2*(max_depth + 1)), dtype=bool)
-
-        pix_id = mocpy.flatten_pixels(self._interval_set._intervals, max_depth)
-        m[pix_id] = True
-
-        if not keep_inside:
-            m = np.logical_not(m)
-
-        ra  = ra  if isinstance(ra, Longitude) else Longitude(ra)
-        dec = dec if isinstance(dec, Latitude) else Latitude(dec)
-
-        pix = cdshealpix.lonlat_to_healpix(ra, dec, max_depth)
-
-        return m[pix]
+        mask = mocpy.space_coverage_contains(self._interval_set._intervals, ra, dec)
+        if keep_inside: 
+            return mask
+        else:
+            return ~mask
 
     ## TODO: implement: def contains_including_surrounding(self, ra, dec, distance)
 

--- a/mocpy/tests/test_moc.py
+++ b/mocpy/tests/test_moc.py
@@ -254,8 +254,10 @@ def test_mpl_border():
 
 
 #### TESTING MOC features ####
-def test_moc_contains():
-    order = 4
+@pytest.mark.parametrize("order", [
+    4, 5, 6, 15, 20, 28
+])
+def test_moc_contains(order):
     size = 20
     healpix_arr = np.random.randint(0, 12*4**order, size)
     all_healpix_arr = np.arange(12*4**order)

--- a/mocpy/tests/test_moc.py
+++ b/mocpy/tests/test_moc.py
@@ -260,7 +260,7 @@ def test_mpl_border():
 def test_moc_contains(order):
     # defines 20 random healpix cells of the required order
     size = 20
-    healpix_arr = np.random.randint(0, 12*4**order, size)
+    healpix_arr = np.random.randint(0, 12*4**order, size, dtype='uint64')
     # defines a moc containing the 20 points
     moc = MOC.from_json(json_moc={str(order): healpix_arr.tolist()})
     # the complementary should not contain them

--- a/mocpy/tests/test_moc.py
+++ b/mocpy/tests/test_moc.py
@@ -258,25 +258,24 @@ def test_mpl_border():
     4, 5, 6, 15, 20, 28
 ])
 def test_moc_contains(order):
+    # defines 20 random healpix cells of the required order
     size = 20
     healpix_arr = np.random.randint(0, 12*4**order, size)
-    all_healpix_arr = np.arange(12*4**order)
-    healpix_outside_arr = np.setdiff1d(all_healpix_arr, healpix_arr)
-
+    # defines a moc containing the 20 points
     moc = MOC.from_json(json_moc={str(order): healpix_arr.tolist()})
-
+    # the complementary should not contain them
+    moc_complement = moc.complement()
+    # coordinates of the 20 random points
     lon, lat = cdshealpix.healpix_to_lonlat(healpix_arr, order)
-    lon_out, lat_out = cdshealpix.healpix_to_lonlat(healpix_outside_arr, order)
-
+    # tests 
     should_be_inside_arr = moc.contains(ra=lon, dec=lat)
     assert should_be_inside_arr.all()
-    should_be_outside_arr = moc.contains(ra=lon_out, dec=lat_out)
+    should_be_outside_arr = moc_complement.contains(ra=lon, dec=lat)
     assert not should_be_outside_arr.any()
-
     # test keep_inside field
     should_be_outside_arr = moc.contains(ra=lon, dec=lat, keep_inside=False)
     assert not should_be_outside_arr.any()
-    should_be_inside_arr = moc.contains(ra=lon_out, dec=lat_out, keep_inside=False)
+    should_be_inside_arr = moc_complement.contains(ra=lon, dec=lat, keep_inside=False)
     assert should_be_inside_arr.all()
 
 

--- a/src/spatial_coverage.rs
+++ b/src/spatial_coverage.rs
@@ -339,6 +339,58 @@ fn from_lower_and_upperd_bounds(low: Array1<u64>, upp: Array1<u64>) -> Array2<u6
     mocranges_to_array2(HpxRanges::<u64>::new_from(ranges))
 }
 
+/// Creates a spatial coverage from a list of sky coordinates.
+///
+/// # Arguments
+///
+/// * ``lon`` - The longitudes of the sky coordinates.
+/// * ``lat`` - The latitudes of the sky coordinates.
+/// * ``ds`` - The depth at which HEALPix cell indices
+///   will be computed.
+///
+/// # Precondition
+///
+/// * ``lon`` and ``lat`` are expressed in radians.
+/// They are valid because they come from
+/// `astropy.units.Quantity` objects.
+///
+/// # Errors
+///
+/// If the number of longitudes and latitudes do not match.
+pub fn contains(
+    coverage: &HpxRanges<u64>,
+    lon: Array1<f64>,
+    lat: Array1<f64>,
+    result: &mut Array1<bool>,
+) -> PyResult<()> {
+    if lon.len() != lat.len() {
+        return Err(exceptions::PyValueError::new_err(
+            "Longitudes and latitudes should have the same length.",
+        ));
+    }
+
+    // Retrieve the spatial depth of the Space coverage
+    let s_depth = coverage.compute_min_depth();
+    let layer = healpix::nested::get(s_depth as u8);
+    let shift = (Hpx::<u64>::MAX_DEPTH - s_depth) << 1;
+    Zip::from(result)
+      .and(&lon)
+      .and(&lat)
+      .par_for_each(|r, &l, &b| {
+          // Compute the HEALPix cell range at the max depth
+          // along the spatial dimension
+          let pix = layer.hash(l, b);
+          let e1 = pix << shift;
+          let e2 = (pix + 1) << shift;
+          
+          // Check whether the (time in µs, HEALPix cell nested range)
+          // is contained into the Time coverage
+          *r = coverage.contains(&(e1..e2));
+      });
+
+    Ok(())
+}
+
 
 /// Convert a spatial coverage from the **uniq** to the **nested** format.
 ///

--- a/src/spatial_coverage.rs
+++ b/src/spatial_coverage.rs
@@ -370,9 +370,7 @@ pub fn contains(
     }
 
     // Retrieve the spatial depth of the Space coverage
-    let s_depth = coverage.compute_min_depth();
-    let layer = healpix::nested::get(s_depth as u8);
-    let shift = (Hpx::<u64>::MAX_DEPTH - s_depth) << 1;
+    let layer = healpix::nested::get(Hpx::<u64>::MAX_DEPTH);
     Zip::from(result)
       .and(&lon)
       .and(&lat)
@@ -380,12 +378,10 @@ pub fn contains(
           // Compute the HEALPix cell range at the max depth
           // along the spatial dimension
           let pix = layer.hash(l, b);
-          let e1 = pix << shift;
-          let e2 = (pix + 1) << shift;
           
           // Check whether the (time in µs, HEALPix cell nested range)
           // is contained into the Time coverage
-          *r = coverage.contains(&(e1..e2));
+          *r = coverage.contains_val(&pix);
       });
 
     Ok(())


### PR DESCRIPTION
# Contains method now works for mocs of max_order > 15. 

Changes include : 
- define rust function adapted from the one already existing for space-time mocs
- contains function was written in python but now calls the rust one
- rework test to test mocs of order > 4
- go to version 11.1 for the bug fix ?