### PR TITLE
add decorator to validate lonlat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed
+
+* all methods of `MOC` with signatures like `function(self, lon, lat, **kwargs)` now accept both lists of coordinates and single coordinates
+
 ## [0.13.0]
 
 ### Added

--- a/python/mocpy/tests/test_moc.py
+++ b/python/mocpy/tests/test_moc.py
@@ -1,5 +1,6 @@
 import pytest
 import copy
+import re
 
 import numpy as np
 
@@ -500,7 +501,12 @@ def test_moc_contains_2d_parameters():
     should_be_inside = moc.contains_lonlat(lon=lon, lat=lat)
     assert should_be_inside.all()
     # test mismatched
-    with pytest.raises(ValueError, match=r"Lon shape different from lat shape.*"):
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "'lon' and 'lat' should have the same shape but are of shapes (2, 3) and (2, 4)",
+        ),
+    ):
         moc.contains_lonlat(lon=lon, lat=lat2)
 
 

--- a/python/mocpy/tests/test_moc.py
+++ b/python/mocpy/tests/test_moc.py
@@ -489,6 +489,9 @@ def test_moc_contains(order):
         keep_inside=False,
     )
     assert should_be_inside_arr.all()
+    # test only floats in arguments, this is a regression test from #108
+    moc = MOC.from_string("2/4")
+    assert moc.contains_lonlat(164.43 * u.deg, 45.54 * u.deg) == [False]
 
 
 # test 2d-arrays as lon lat input


### PR DESCRIPTION
This PR add a decorator to the function taking longitudes and latitudes as parameters.

The decorator does the following: 
- check that shapes of `lon` and `lat` are compatible
- transforms in atleast1D for compatibility with type `PyReadonlyArrayDyn<f64>`
- converts to degrees in case we got an other unit in entry

This is applied to the following methods: 
- `contains_lonlat`
- `from_lonlat`
- `from_elliptical_cone`
- `from_cone`
- `from_ring`
- `from_polygon`

It solves issues #108  and #87 