### PR TITLE
MNT: upgrade upload/download-artifact GitHub actions

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -33,7 +33,7 @@ jobs:
           sccache: 'true'
           rust-toolchain: nightly
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wasm-wheels
           path: dist


### PR DESCRIPTION
Hi, version 4 of upload-artifact and download-artifact were recently released.
Staying on old version is not viable long term because GitHub will sooner or later drop support for the old versions of node that these depend on.
Since migration to v4 is not as straightfoward as bumping the version number, I'm helping all astropy-related packages byt manually performing the necessary changes.

(in this specific case it is actually trivial, I'm just doing them all at once so no reason to skip this repo)
