### PR TITLE
Multi-order Maps functionnalities

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -158,7 +158,7 @@ jobs:
         MATURIN_PASSWORD: ${{ secrets.PYPI_PASSWORD_FXP }}
        run: |
          #python3 -m pip install maturin
-         rustup target add aarch64-apple-darwin
+         rustup target add x86_64-apple-darwin
          pip install --upgrade pip
          pip install maturin
          maturin -V

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
      - name: "Build and test wheel for Python ${{ matrix.python-version }} on MacOS"
        run: |
          # Install, create and activate a python virtualenv
-         rustup target add aarch64-apple-darwin
+         rustup target add x86_64-apple-darwin
          pip install virtualenv
          virtualenv mocpy-env
          source mocpy-env/bin/activate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* `MOC.sum_in_multiordermap_intersection` takes an astropy table with a `UNIQ` column and
+* `MOC.sum_in_multiordermap` takes an astropy table with a `UNIQ` column and
 a column name to sum. It returns the sum of the column in the intersection between the
-MOC and the Multi-order-map. `MOC.probability_in_multiordermap_intersection` has a similar
+MOC and the Multi-order-map. `MOC.probability_in_multiordermap` has a similar
 behavior but also converts a probability-density into a probability.
 * `STMOC.new_empty()` allows to create a new empty Space-Time MOC.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+* `MOC.sum_in_multiordermap_intersection` takes an astropy table with a `UNIQ` column and
+a column name to sum. It returns the sum of the column in the intersection between the
+MOC and the Multi-order-map. `MOC.probability_in_multiordermap_intersection` has a similar
+behavior but also converts a probability-density into a probability.
+
 ## [0.13.1]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 a column name to sum. It returns the sum of the column in the intersection between the
 MOC and the Multi-order-map. `MOC.probability_in_multiordermap_intersection` has a similar
 behavior but also converts a probability-density into a probability.
+* `STMOC.new_empty()` allows to create a new empty Space-Time MOC.
 
 ## [0.13.1]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ bench = true
 crate-type = ["cdylib"]
 
 [dependencies]
-moc = { version = "0.12", features = ["storage"] }
+moc = { version = "0.13", features = ["storage"] }
 healpix = { package = "cdshealpix", version = "0.6" }
 # moc = { git = 'https://github.com/cds-astro/cds-moc-rust', branch = 'main', features = ["storage"] }
 # healpix = { package = "cdshealpix", git = 'https://github.com/cds-astro/cds-healpix-rust', branch = 'master' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ bench = true
 crate-type = ["cdylib"]
 
 [dependencies]
-# moc = { version = "0.13", features = ["storage"] }
-moc = { git = 'https://github.com/cds-astro/cds-moc-rust', branch = 'main', features = ["storage"] }
+moc = { version = "0.14", features = ["storage"] }
+# moc = { git = 'https://github.com/cds-astro/cds-moc-rust', branch = 'main', features = ["storage"] }
 healpix = { package = "cdshealpix", version = "0.6" }
 # healpix = { package = "cdshealpix", git = 'https://github.com/cds-astro/cds-healpix-rust', branch = 'master' }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,13 @@ bench = true
 crate-type = ["cdylib"]
 
 [dependencies]
-moc = { version = "0.13", features = ["storage"] }
+# moc = { version = "0.13", features = ["storage"] }
+moc = { git = 'https://github.com/cds-astro/cds-moc-rust', branch = 'main', features = ["storage"] }
 healpix = { package = "cdshealpix", version = "0.6" }
-# moc = { git = 'https://github.com/cds-astro/cds-moc-rust', branch = 'main', features = ["storage"] }
 # healpix = { package = "cdshealpix", git = 'https://github.com/cds-astro/cds-healpix-rust', branch = 'master' }
 
 [dependencies.numpy]
-version = "0.17"
+version = "0.19"
 
 [dependencies.ndarray]
 version = "0.15"
@@ -42,7 +42,7 @@ default-features = false # do not include the default features, and optionally
 features = ["rayon"]
 
 [dependencies.pyo3]
-version = "0.17.3"
+version = "0.19"
 features = ["extension-module"]
 
 [profile.release]

--- a/docs/examples/bayestar.py
+++ b/docs/examples/bayestar.py
@@ -4,12 +4,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 from astropy.coordinates import Angle, SkyCoord
 from astropy.io import fits
-
 from mocpy import MOC, WCS
 
+# this can be found in mocpy's repository
+# https://github.com/cds-astro/mocpy/blob/master/resources/bayestar.multiorder.fits
 fits_image_filename = "./../../resources/bayestar.multiorder.fits"
 
-max_order = None
 with fits.open(fits_image_filename) as hdul:
     hdul.info()
     data = hdul[1].data
@@ -18,13 +18,12 @@ with fits.open(fits_image_filename) as hdul:
 uniq = data["UNIQ"]
 probdensity = data["PROBDENSITY"]
 
-
+# let's convert the probability density into a probability
 level, ipix = ah.uniq_to_level_ipix(uniq)
 area = ah.nside_to_pixel_area(ah.level_to_nside(level)).to_value(u.steradian)
-
 prob = probdensity * area
 
-
+# now we create the mocs corresponding to different probability thresholds
 cumul_to = np.linspace(0.5, 0.9, 5)[::-1]
 colors = ["blue", "green", "yellow", "orange", "red"]
 mocs = [
@@ -33,8 +32,6 @@ mocs = [
 
 
 # Plot the MOC using matplotlib
-
-
 fig = plt.figure(111, figsize=(15, 10))
 # Define a astropy WCS easily
 with WCS(
@@ -58,9 +55,7 @@ with WCS(
             label="confidence probability " + str(round(c * 100)) + "%",
         )
         moc.border(ax=ax, wcs=wcs, alpha=0.5, color=col)
-
     ax.legend()
-
 plt.xlabel("ra")
 plt.ylabel("dec")
 plt.title("Bayestar")

--- a/docs/examples/user_documentation.rst
+++ b/docs/examples/user_documentation.rst
@@ -82,9 +82,13 @@ In this example:
 Gravitational Waves MOCs
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-This example shows the probability confidence regions of gravitational waves. HEALPix cells are given under the `uniq pixel notation <http://www.ivoa.net/documents/Notes/MOC/20120412/NOTE-MOC-1.0-20120412.pdf>`__. Each
-pixel is associated with a specific value. We can create a MOC from which a GW has x% of change of being localized in it. By definition the MOC which has 100% of chance
-of containing a GW is the full sky MOC.
+This example shows the probability confidence regions of gravitational waves.
+HEALPix cells are given under the
+`uniq pixel notation <http://www.ivoa.net/documents/Notes/MOC/20120412/NOTE-MOC-1.0-20120412.pdf>`__.
+Each pixel is associated with a specific probability density value. We convert this into
+a probability by multiplying it with the area of each cell.
+Then, we can create a MOC from which a GW has x% of chance of being localized in it.
+By definition the MOC which has 100% of chance of containing a GW is the full sky MOC.
 
 .. plot:: examples/bayestar.py
     :include-source:

--- a/python/mocpy/moc/moc.py
+++ b/python/mocpy/moc/moc.py
@@ -719,7 +719,7 @@ class MOC(AbstractMOC):
         )
         return cls(index)
 
-    def probability_in_multiordermap_intersection(self, multiordermap):
+    def probability_in_multiordermap(self, multiordermap):
         """Calculate the probability in the intersection between the multiordermap and the MOC.
 
         ``PROBDENSITY`` values are multiplied by the area of their associated HEALPix
@@ -752,7 +752,7 @@ class MOC(AbstractMOC):
         >>> probdensity = rng.random(20) / 100
         >>> multi_order_map = Table([uniq, probdensity], names=("UNIQ", "PROBDENSITY"))
         >>> # The probability to be in the intersection with the all sky is
-        >>> round(all_sky.probability_in_multiordermap_intersection(multi_order_map), 4)
+        >>> round(all_sky.probability_in_multiordermap(multi_order_map), 4)
         0.0004
 
         """
@@ -783,7 +783,7 @@ class MOC(AbstractMOC):
             f" is expected. Got '{type(multiordermap)}'",
         )
 
-    def sum_in_multiordermap_intersection(self, multiordermap: Table, column: str):
+    def sum_in_multiordermap(self, multiordermap: Table, column: str):
         """Calculate the sum of a column from a multiordermap in the intersection with the MOC.
 
         Parameters
@@ -811,7 +811,7 @@ class MOC(AbstractMOC):
         >>> rng = np.random.default_rng(0)
         >>> column = rng.random(200)
         >>> multi_order_map = Table([uniq, column], names=("UNIQ", "column"))
-        >>> round(all_sky.sum_in_multiordermap_intersection(multi_order_map, "column"), 4)
+        >>> round(all_sky.sum_in_multiordermap(multi_order_map, "column"), 4)
         107.9259
 
         """

--- a/python/mocpy/stmoc/stmoc.py
+++ b/python/mocpy/stmoc/stmoc.py
@@ -39,7 +39,7 @@ class STMOC(AbstractMOC):
     @property
     def max_order(self):
         """Is a clone of max_depth, to preserve the api between moc types."""
-        return self.max_depth()
+        return self.max_depth
 
     @property
     def max_time(self):
@@ -85,10 +85,31 @@ class STMOC(AbstractMOC):
         )
 
     @classmethod
-    def new_empty(cls):
-        """Create a new empty STMOC."""
-        # TODO
-        raise NotImplementedError("This method is not implemented yet.")
+    def new_empty(cls, max_depth_space, max_depth_time):
+        """Create a new empty STMOC.
+
+        Parameters
+        ----------
+        max_depth_space : int
+            The space resolution of the STMOC. Should be comprised between 0 and 29.
+        max_depth_time : int
+            The time resolution of the STMOC. Should be comprised between 0 and 61.
+
+        Returns
+        -------
+        `~mocpy.moc.STMOC`
+
+        Examples
+        --------
+        >>> from mocpy import STMOC
+        >>> STMOC.new_empty(12, 42)
+
+        """
+        index = mocpy.new_empty_stmoc(
+            np.uint8(max_depth_time),
+            np.uint8(max_depth_space),
+        )
+        return cls(index)
 
     def is_empty(self):
         """Check whether the Space-Time coverage is empty."""

--- a/python/mocpy/stmoc/stmoc.py
+++ b/python/mocpy/stmoc/stmoc.py
@@ -85,15 +85,15 @@ class STMOC(AbstractMOC):
         )
 
     @classmethod
-    def new_empty(cls, max_depth_space, max_depth_time):
+    def new_empty(cls, max_depth_time, max_depth_space):
         """Create a new empty STMOC.
 
         Parameters
         ----------
-        max_depth_space : int
-            The space resolution of the STMOC. Should be comprised between 0 and 29.
         max_depth_time : int
             The time resolution of the STMOC. Should be comprised between 0 and 61.
+        max_depth_space : int
+            The space resolution of the STMOC. Should be comprised between 0 and 29.
 
         Returns
         -------
@@ -102,7 +102,8 @@ class STMOC(AbstractMOC):
         Examples
         --------
         >>> from mocpy import STMOC
-        >>> STMOC.new_empty(12, 42)
+        >>> STMOC.new_empty(42, 12)
+        t42/ s12/
 
         """
         index = mocpy.new_empty_stmoc(

--- a/python/mocpy/tests/test_moc.py
+++ b/python/mocpy/tests/test_moc.py
@@ -741,18 +741,18 @@ def test_from_valued_healpix_cells_bayestar_and_split():
         assert moc.max_order == 11
 
 
-def test_probability_in_multiordermap_intersection():
+def test_probability_in_multiordermap():
     # from path
     moc = MOC.from_str("0/4")
     fits_mom_filename = "./resources/bayestar.multiorder.fits"
-    proba = moc.probability_in_multiordermap_intersection(fits_mom_filename)
+    proba = moc.probability_in_multiordermap(fits_mom_filename)
     assert np.isclose(proba, 0.20877154164727782)
 
     # has no mask
     mom = QTable()
     mom["UNIQ"] = [4 + x for x in range(20)]
     mom["PROBDENSITY"] = [x / 10 for x in range(20)]
-    proba = moc.probability_in_multiordermap_intersection(mom)
+    proba = moc.probability_in_multiordermap(mom)
     assert np.isclose(proba, 0.41887902047863906)
 
     # is not a valid mom or path
@@ -761,16 +761,16 @@ def test_probability_in_multiordermap_intersection():
         match="An argument of type 'str', 'pathlib.Path', or "
         "'astropy.table.Table' is expected. Got '<class 'int'>'",
     ):
-        moc.probability_in_multiordermap_intersection(1)
+        moc.probability_in_multiordermap(1)
 
 
-def test_sum_in_multiordermap_intersection():
+def test_sum_in_multiordermap():
     all_sky = MOC.from_str("0/0-11")
     mom = QTable()
     range_20 = range(20)
     mom["UNIQ"] = [4 * 4**3 + x for x in range_20]
     mom["TO_SUM"] = range_20
-    assert all_sky.sum_in_multiordermap_intersection(mom, "TO_SUM") == sum(range_20)
+    assert all_sky.sum_in_multiordermap(mom, "TO_SUM") == sum(range_20)
 
 
 def test_from_stcs():

--- a/python/mocpy/tests/test_stmoc.py
+++ b/python/mocpy/tests/test_stmoc.py
@@ -52,6 +52,10 @@ def stmoc_xmm_dr8():
     )
 
 
+def test_new_empty():
+    assert STMOC.new_empty(0, 0).is_empty()
+
+
 def test_n_cells():
     assert STMOC.n_cells(0, "time") == 2
     assert STMOC.n_cells(0, "space") == 12

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1450,10 +1450,10 @@ fn mocpy(_py: Python, m: &PyModule) -> PyResult<()> {
           .zip(value_mask.as_array().into_iter().cloned()),
       )
       .filter_map(|(key_val, (mask_key, mask_val))| {
-        if mask_key & mask_val {
-          Some(key_val)
-        } else {
+        if mask_key | mask_val {
           None
+        } else {
+          Some(key_val)
         }
       });
     U64MocStore::get_global_store()
@@ -2142,6 +2142,13 @@ fn mocpy(_py: Python, m: &PyModule) -> PyResult<()> {
   fn new_empty_fmoc(depth: u8) -> PyResult<usize> {
     U64MocStore::get_global_store()
       .new_empty_fmoc(depth)
+      .map_err(PyIOError::new_err)
+  }
+
+  #[pyfn(m)]
+  fn new_empty_stmoc(depth_time: u8, depth_space: u8) -> PyResult<usize> {
+    U64MocStore::get_global_store()
+      .new_empty_stmoc(depth_time, depth_space)
       .map_err(PyIOError::new_err)
   }
 


### PR DESCRIPTION
This PR adds two new methods for the Space MOCs:

- `MOC.sum_in_multiordermap(MOM: astropy.tableTable, column_to_sum: str)` returns the sum of a column in the intersection between a MOM and the MOC
- `MOC.probability_in_multiorderma(MOM, pathlib.Path or astropy.table.Table)` does convert a `PROBDENSITY` column into probability automatically

Fixes #125 

  