### PR TITLE
fix: opening a moc from a pickle now increments the number of refs to the object in store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `MOC.border` no does not attempt on plotting the border when the MOc is out of the
 view anymore.
+* fix an issue where the number of references to the rust side was not
+incremented when a moc was created from a pickle file. This also solves a lot of issues
+with the multiprocessing module that calls pickle behind the scenes.
 
 ### Added
 

--- a/python/mocpy/abstract_moc.py
+++ b/python/mocpy/abstract_moc.py
@@ -51,6 +51,12 @@ class AbstractMOC(serializer.IO, metaclass=abc.ABCMeta):
     def __deepcopy__(self, memo):
         return self.__copy__()
 
+    def __setstate__(self, state):
+        # this is called when a MOC is unpickled
+        # we create a new ref count with copy
+        mocpy.copy(state["store_index"])
+        self.__dict__ = state
+
     @staticmethod
     def _store_index_dtype():
         """Store the datatype of the index.


### PR DESCRIPTION
This PR add an incrementalist of the numbers of references to the MOC in the store when a moc is created out of a pickle. This should solve the multiprocessing issues that call pickle behind the scenes.

Fixes #102 #133 #132 