### PR TITLE
Switch to use VizieR microservice instead of the MOCServer in from_vizier_table

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,7 @@ jobs:
     # See https://github.com/pypa/manylinux for this particular container:
     # * CPython 3.8, 3.9, 3.10, 3.11 and 3.12 installed in /opt/python/<python tag>-<abi tag>
     container: quay.io/pypa/manylinux2014_x86_64:latest
+    env: {ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true} # Allow using Node16 actions required for CentOS7
     steps:
      - name: "Checkout the full project"
        uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
     # See https://github.com/pypa/manylinux for this particular container:
     # * CPython 3.7, 3.8, 3.9, 3.10 and 3.11 installed in /opt/python/<python tag>-<abi tag>
     container: quay.io/pypa/manylinux2014_x86_64
+    env: {ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true} # Allow using Node16 actions required for CentOS7
     steps:
      - name: "Checkout branch ${{ github.head_ref }}"
        uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+* the `mocpy.WCS` class can now accept a sequence of angles as its fov argument rather than always
+representing square areas of the sky.
+* `MOC.from_polygons` and `MOC.from_polygons` now accept a boolean `complement` that allows to chose
+between the small MOC described by the polygon or the bigger one (its complement)
+
+### Changed
+
+* `MOC.from_vizier_table()` does not call the MOCServer anymore. It now raises an error if the
+catalog of table name is invalid (see #143). It also accepts `max_depth` as an argument. This
+should replace `nside` in a future version.
+* `MOC.from_ivorn()` now accepts `max_depth` as an argument. This should reb=place `nside` later.
+
 ## [0.15.0]
 
 ### Added
@@ -23,10 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * a new method `MOC.from_cones` allows to create a list of MOCs from a list of centers
 and radii. This is multi-threaded.
 * new method `MOC.from_boxes` allows to create lists of MOCs from boxes. This is multi-threaded.
-* the `mocpy.WCS` class can now accept a sequence of angles as its fov argument rather than always
-representing square areas of the sky.
-* `MOC.from_polygons` and `MOC.from_polygons` now accept a boolean `complement` that allows to chose
-between the small MOC described by the polygon or the bigger one (its complement)
 
 ### Changed
 

--- a/python/mocpy/tests/test_moc.py
+++ b/python/mocpy/tests/test_moc.py
@@ -266,6 +266,41 @@ def test_from_polygons():
     assert list_mocs == list_mocs_no_skycoord
 
 
+def test_from_vizier():
+    # deprecated nside should still work (nside=8 means order=3)
+    with pytest.warns(
+        DeprecationWarning,
+        match="'nside' is deprecated in favor of 'max_depth'.*",
+    ):
+        moc = MOC.from_vizier_table("I/355", nside=8)
+    assert moc.max_order == 3
+    # gaia is the whole sky at order 3
+    assert moc.sky_fraction == 1
+    with pytest.warns(
+        DeprecationWarning,
+        match="'nside' is deprecated in favor of 'max_depth'.*",
+    ), pytest.raises(ValueError, match="Bad value for nside.*"):
+        moc = MOC.from_vizier_table("I/355", nside=1)
+    moc = MOC.from_vizier_table("I/355")
+    # default order is 10 for catalogs
+    assert moc.max_order == 10
+    # non valid table or catalog
+    with pytest.raises(ValueError, match="No catalog/table was found for 'abc'*"):
+        moc = MOC.from_vizier_table("abc")
+
+
+def test_from_ivorn():
+    with pytest.warns(
+        DeprecationWarning,
+        match="'nside' is deprecated in favor of 'max_depth'.*",
+    ):
+        moc = MOC.from_ivorn("ivo://CDS/J/A+AS/133/387/table5", nside=8)
+    assert moc.max_order == 3
+
+    with pytest.warns(UserWarning, match="This MOC is empty.*"):
+        MOC.from_ivorn("abc")
+
+
 def test_moc_from_fits():
     fits_path = "resources/P-GALEXGR6-AIS-FUV.fits"
     MOC.load(fits_path, "fits")


### PR DESCRIPTION
It has better resolution and raises errors when it should.

Additionnaly, we raise a warning for empty response in from_ivorn that is still connected to the MOCServer. There is no way to do a distinction between a wrong table name and a table without positions (for example with a timemoc).