### PR TITLE
Add methods to filter multiordermaps by MOCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `MOC.mask_uniq` allows to mas an array of uniq cells with a MOC
+* `MOC.values_and_weights_in_multiorder_map` allows to filter a multiordermap by a MOC with
+weights corresponding to the area of the cells intersecting the MOC and the multiordermap
 * the `mocpy.WCS` class can now accept a sequence of angles as its fov argument rather than always
 representing square areas of the sky.
 * `MOC.from_polygons` and `MOC.from_polygons` now accept a boolean `complement` that allows to chose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ bench = true
 crate-type = ["cdylib"]
 
 [dependencies]
-moc = { version = "0.15", features = ["storage"] }
-# moc = { git = 'https://github.com/cds-astro/cds-moc-rust', branch = 'main', features = ["storage"] }
+# moc = { version = "0.15", features = ["storage"] }
+moc = { git = 'https://github.com/cds-astro/cds-moc-rust', branch = 'main', features = ["storage"] }
 healpix = { package = "cdshealpix", version = "0.6" }
 # healpix = { package = "cdshealpix", git = 'https://github.com/cds-astro/cds-healpix-rust', branch = 'master' }
 rayon = "1.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bench = true
 crate-type = ["cdylib"]
 
 [dependencies]
-moc = { version = "0.14", features = ["storage"] }
+moc = { version = "0.15", features = ["storage"] }
 # moc = { git = 'https://github.com/cds-astro/cds-moc-rust', branch = 'main', features = ["storage"] }
 healpix = { package = "cdshealpix", version = "0.6" }
 # healpix = { package = "cdshealpix", git = 'https://github.com/cds-astro/cds-healpix-rust', branch = 'master' }
@@ -36,7 +36,7 @@ rayon = "1.10"
 num_threads = "0.1"
 
 [dependencies.numpy]
-version = "0.20"
+version = "0.21"
 
 [dependencies.ndarray]
 version = "0.15"
@@ -45,7 +45,7 @@ default-features = false # do not include the default features, and optionally
 features = ["rayon"]
 
 [dependencies.pyo3]
-version = "0.20"
+version = "0.21"
 features = ["extension-module"]
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # moc = { version = "0.15", features = ["storage"] }
-moc = { git = 'https://github.com/cds-astro/cds-moc-rust', branch = 'main', features = ["storage"] }
+moc = { git = 'https://github.com/cds-astro/cds-moc-rust', rev = 'f4bbcab15ce705d4af8aace03286b947a51deea6', features = ["storage"] }
 healpix = { package = "cdshealpix", version = "0.6" }
 # healpix = { package = "cdshealpix", git = 'https://github.com/cds-astro/cds-healpix-rust', branch = 'master' }
 rayon = "1.10"

--- a/python/mocpy/moc/moc.py
+++ b/python/mocpy/moc/moc.py
@@ -1018,6 +1018,50 @@ class MOC(AbstractMOC):
             *_extract_mask_and_values_multiordermap(multiordermap, column),
         )
 
+    def mask_uniq(self, uniq, uniq_mask=None, fully_covered_only=False):
+        """Get a mask for an array of uniq cells intersecting the MOC.
+
+        Parameters
+        ----------
+        uniq : `~np.array`
+            An array on integers corresponding to HEALPix cells in the uniq notation.
+        uniq_mask : `~np.array`, optional
+            An optional array to mask the uniq array. Set to True where the values of the
+            uniq array should be ignored (following the numpy `~np.ma.masked_array`
+            convention).
+        fully_covered_only : bool, optional
+            If True, keep only uniq cells that are fully covered by the MOC.
+            Otherwise, also keep cells that intersect the MOC.
+            By default False.
+
+        Returns
+        -------
+        `~np.array`
+            A mask that is True where the uniq cell is comprised (or at least intersects
+            depending on 'fully_covered_only') in the MOC and False otherwise
+
+        Examples
+        --------
+        >>> from mocpy import MOC
+        >>> uniq = [4 * 4**3 + x for x in range(8)] # corresponds to 3/0-7
+        >>> moc = MOC.from_str("3/4-20")
+        >>> moc.mask_uniq(uniq) # the first four cells are NOT intersecting
+        array([False, False, False, False,  True,  True,  True,  True])
+
+        """
+        index = self.store_index
+        if uniq_mask is None:
+            uniq_mask = np.array(np.zeros(len(uniq)), dtype=bool)
+        else:
+            uniq_mask = np.array(uniq_mask, dtype=bool)
+        mocpy.multiorder_filter_mask_in_smoc(
+            index,
+            np.array(uniq, dtype="uint64"),
+            uniq_mask,
+            fully_covered_only,
+        )
+        return np.logical_not(uniq_mask)
+
     @classmethod
     def from_valued_healpix_cells(
         cls,

--- a/python/mocpy/moc/moc.py
+++ b/python/mocpy/moc/moc.py
@@ -103,6 +103,40 @@ def _mask_unsigned_before_casting(indices):
     return np.array(indices) > 0
 
 
+def _extract_mask_and_values_multiordermap(multiordermap, column):
+    """Extract uniq and values with their masks.
+
+    Parameters
+    ----------
+    multiordermap : astropy.table.Table
+        The table should have a column named ``UNIQ`` that corresponds to HEALPix
+        cells in the uniq notation.
+    column : str
+        The name of the column to retrieve. It should contain float-compatible values.
+
+    Returns
+    -------
+    (uniq, uniq_mask, values, values_mask)
+    """
+    uniq = multiordermap["UNIQ"]
+    values = multiordermap[column]
+    try:
+        uniq_mask = uniq.data.mask
+    except AttributeError:
+        uniq_mask = np.zeros(uniq.shape)
+    try:
+        values_mask = values.data.mask
+    except AttributeError:
+        values_mask = np.zeros(uniq.shape)
+
+    return (
+        np.array(uniq.data, dtype="uint64"),
+        np.array(uniq_mask, dtype="bool"),
+        np.array(values.data, dtype="float"),
+        np.array(values_mask, dtype="bool"),
+    )
+
+
 class MOC(AbstractMOC):
     """
     Multi-order spatial coverage class.
@@ -862,22 +896,9 @@ class MOC(AbstractMOC):
             dtype=cls._store_index_dtype(),
         )
 
-        uniq = multiordermap["UNIQ"]
-        probdensity = multiordermap["PROBDENSITY"]
-
-        try:
-            uniq_mask = uniq.data.mask
-            probdensity_mask = probdensity.data.mask
-        except AttributeError:
-            uniq_mask = np.zeros(uniq.shape)
-            probdensity_mask = np.zeros(probdensity.shape)
-
         return mocpy.multi_multiorder_probdens_map_sum_in_smoc(
             indices,
-            np.array(uniq.data, dtype="uint64"),
-            np.array(uniq_mask, dtype="bool"),
-            np.array(probdensity.data, dtype="float"),
-            np.array(probdensity_mask, dtype="bool"),
+            *_extract_mask_and_values_multiordermap(multiordermap, "PROBDENSITY"),
             n_threads,
         )
 
@@ -925,21 +946,9 @@ class MOC(AbstractMOC):
         index = self.store_index
 
         if isinstance(multiordermap, Table):
-            uniq = multiordermap["UNIQ"]
-            probdensity = multiordermap["PROBDENSITY"]
-            try:
-                uniq_mask = uniq.data.mask
-                probdensity_mask = probdensity.data.mask
-            except AttributeError:
-                uniq_mask = np.zeros(uniq.shape)
-                probdensity_mask = np.zeros(probdensity.shape)
-
             return mocpy.multiorder_probdens_map_sum_in_smoc(
                 index,
-                np.array(uniq.data, dtype="uint64"),
-                np.array(uniq_mask, dtype="bool"),
-                np.array(probdensity.data, dtype="float"),
-                np.array(probdensity_mask, dtype="bool"),
+                *_extract_mask_and_values_multiordermap(multiordermap, "PROBDENSITY"),
             )
         if isinstance(multiordermap, (Path, str)):
             return mocpy.multiordermap_sum_in_smoc_from_file(index, str(multiordermap))
@@ -955,10 +964,10 @@ class MOC(AbstractMOC):
         Parameters
         ----------
         multiordermap : astropy.table.Table
-            The table should have a ``UNIQ`` that corresponds to HEALPix cells in the uniq
-            notation.
+            The table should have a column ``UNIQ`` that corresponds to HEALPix cells
+            in the uniq notation.
         column : str
-            The name of the column to sum.
+            The name of the column to sum. It should be compatible with a float conversion.
 
         Returns
         -------
@@ -982,21 +991,31 @@ class MOC(AbstractMOC):
 
         """
         index = self.store_index
-        uniq = multiordermap["UNIQ"]
-        values_to_sum = multiordermap[column]
-        try:
-            uniq_mask = uniq.data.mask
-            values_to_sum_mask = values_to_sum.data.mask
-        except AttributeError:
-            uniq_mask = np.zeros(uniq.shape)
-            values_to_sum_mask = uniq_mask
-
         return mocpy.multiordermap_sum_in_smoc(
             index,
-            np.array(uniq.data, dtype="uint64"),
-            np.array(uniq_mask, dtype="bool"),
-            np.array(values_to_sum.data, dtype="float"),
-            np.array(values_to_sum_mask, dtype="bool"),
+            *_extract_mask_and_values_multiordermap(multiordermap, column),
+        )
+
+    def values_and_weights_in_multiordermap(self, multiordermap: Table, column: str):
+        """Calculate the sum of a column from a multiordermap in the intersection with the MOC.
+
+        Parameters
+        ----------
+        multiordermap : astropy.table.Table
+            The table should have a column ``UNIQ`` that corresponds to HEALPix cells
+            in the uniq notation.
+        column : str
+            The name of the column to return. It should be compatible with a float conversion.
+
+        Returns
+        -------
+        Tuple(np.ndarray, np.ndarray)
+
+        """
+        index = self.store_index
+        return mocpy.multiorder_values_and_weights_in_smoc(
+            index,
+            *_extract_mask_and_values_multiordermap(multiordermap, column),
         )
 
     @classmethod

--- a/python/mocpy/tests/test_moc.py
+++ b/python/mocpy/tests/test_moc.py
@@ -199,6 +199,12 @@ def test_complement():
 # --- TESTING MOC creation ---#
 
 
+def test_new_empty_serialization():
+    # regression test for https://github.com/cds-astro/mocpy/issues/146
+    empty = MOC.new_empty(max_depth=0)
+    assert empty.serialize("json") == {"0": []}
+
+
 def get_random_skycoords(size):
     return SkyCoord(
         ra=np.random.uniform(0, 360, size),

--- a/python/mocpy/tests/test_moc.py
+++ b/python/mocpy/tests/test_moc.py
@@ -984,6 +984,26 @@ def test_sum_in_multiordermap():
     assert all_sky.sum_in_multiordermap(mom, "TO_SUM") == sum(range_20)
 
 
+def test_values_and_weights_in_multiordermap():
+    all_sky = MOC.from_str("0/0-11")
+    mom = QTable()
+    range_20 = range(20)
+    uniq = np.array([4 * 4**3 + x for x in range_20])
+    mom["UNIQ"] = uniq
+    mom["values"] = range_20
+    values, weights = all_sky.values_and_weights_in_multiordermap(mom, "values")
+    assert all(values == mom["values"])
+    assert all(np.isclose(weight, 4 * math.pi / (12 * 4**3)) for weight in weights)
+
+    one_cell = MOC.from_str("3/0")
+    mom = QTable()
+    mom["values"] = [0, 1, 2, 3]
+    mom["UNIQ"] = [4 * 4**2 + x for x in [0, 1, 2, 3]]  # corresponds to "1/0"
+    values, weights = one_cell.values_and_weights_in_multiordermap(mom, "values")
+    assert all(values == np.array([0]))
+    assert all(np.isclose(weights, one_cell.sky_fraction * 4 * math.pi))
+
+
 def test_from_stcs():
     moc1 = MOC.from_stcs("Circle ICRS 147.6 69.9 0.4", 14, 2)
     moc2 = MOC.from_cone(

--- a/python/mocpy/tests/test_moc.py
+++ b/python/mocpy/tests/test_moc.py
@@ -1004,6 +1004,21 @@ def test_values_and_weights_in_multiordermap():
     assert all(np.isclose(weights, one_cell.sky_fraction * 4 * math.pi))
 
 
+def test_mask_uniq():
+    uniq = [4 * 4**3 + x for x in range(8)]
+    moc = MOC.from_str("3/4-20")
+    assert all(
+        moc.mask_uniq(uniq) == [False, False, False, False, True, True, True, True],
+    )
+
+    # fully covered should have less matches
+    cone1 = MOC.from_cone(20 * u.deg, 20 * u.deg, radius=2 * u.deg, max_depth=10)
+    cone2 = MOC.from_cone(21 * u.deg, 21 * u.deg, radius=2 * u.deg, max_depth=10)
+    assert sum(cone1.mask_uniq(cone2.uniq_hpx)) > sum(
+        cone1.mask_uniq(cone2.uniq_hpx, fully_covered_only=True),
+    )
+
+
 def test_from_stcs():
     moc1 = MOC.from_stcs("Circle ICRS 147.6 69.9 0.4", 14, 2)
     moc2 = MOC.from_cone(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2064,6 +2064,30 @@ fn mocpy(m: &Bound<'_, PyModule>) -> PyResult<()> {
       .map_err(PyIOError::new_err)
   }
 
+  /// Set to 'false' the booleans associated to the UNIQ HEALPix cells
+  /// intersecting (or fully covered) by the MOC of given index.
+  ///
+  /// # Arguments
+  ///
+  /// * ``index`` - The index of the coverage in the store.
+  /// * ``uniq`` - UNIQ HEALPix values.
+  /// * ``uniq_mask`` - Mask on the UNIQ HEALPix values.
+  /// * `fully_covered_only`: set the boolean to false only if the cell is fully covered (else if it intersects)
+  #[pyfn(m)]
+  fn multiorder_filter_mask_in_smoc<'a>(
+    index: usize,
+    uniq: PyReadonlyArrayDyn<'a, u64>,
+    uniq_mask: &Bound<'a, PyArrayDyn<bool>>,
+    fully_covered_only: bool,
+  ) -> PyResult<()> {
+    let uniq = uniq.as_array();
+    let mut flags = unsafe { uniq_mask.as_array_mut() };
+    let it = uniq.into_iter().cloned().zip(flags.iter_mut());
+    U64MocStore::get_global_store()
+      .multiordermap_filter_mask_moc(index, it, fully_covered_only)
+      .map_err(PyIOError::new_err)
+  }
+
   /// Deserialize a spatial MOC from a FITS file.
   ///
   /// # Arguments


### PR DESCRIPTION
Adds two methods for multiordermaps users: 

- `MOC.values_and_weights_in_multiorder_map` allows to filter a multiordermap by a MOC with
weights corresponding to the area of the cells intersecting the MOC and the multiordermap
- `MOC.mask_uniq` is a lightweight version that allows to mask an array of uniq cells with a MOC


(also solves the serialization into json issue #146 )