### PR TITLE
Update intersphinx links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -242,14 +242,8 @@ texinfo_documents = [
 
 # Include other packages to link against
 
-intersphinx_mapping = {
-    "python": ("https://docs.python.org/", None),
-    "astropy": ("http://docs.astropy.org/en/latest/", None),
-    "matplotlib": ("https://matplotlib.org/", None),
-    "networkx": ("https://networkx.github.io/documentation/stable/", None),
-    "numpy": ("https://numpy.org/doc/stable/", None),
-    "regions": ("https://astropy-regions.readthedocs.io/en/stable", None),
-}
+intersphinx_mapping["networkx"] = ("https://networkx.org/documentation/stable/objects.inv", None)
+intersphinx_mapping["regions"] = ("https://astropy-regions.readthedocs.io/en/stable", None)
 
 
 def setup(app):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -242,7 +242,7 @@ texinfo_documents = [
 
 # Include other packages to link against
 
-intersphinx_mapping["networkx"] = ("https://networkx.org/documentation/stable/objects.inv", None)
+intersphinx_mapping["networkx"] = ("https://networkx.org/documentation/stable", None)
 intersphinx_mapping["regions"] = ("https://astropy-regions.readthedocs.io/en/stable", None)
 
 


### PR DESCRIPTION
A sphinx build surfaces several warnings on updated intersphinx locations. While nothing is currently broken, it's probably good to fix before it does.

A "default" intersphinx is imported from `sphinx_astropy` which contains links for python, numpy, matplotlib and astropy itself. Using that instead of hard-coding here shifts the burden to maintain links to the astropy team and avoids duplicated work. Packages not in that list are added to to dict here.