### PR TITLE
fix: query_vizier_table not covered by tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changed
+
+* Calls to the xmatch service are now done in https [#xxx]
+
 ## [0.18.0]
 
 ### Fixed

--- a/python/mocpy/moc/moc.py
+++ b/python/mocpy/moc/moc.py
@@ -2429,7 +2429,7 @@ class MOC(AbstractMOC):
         moc_fits.writeto(moc_file)
 
         r = requests.post(
-            "http://cdsxmatch.u-strasbg.fr/QueryCat/QueryCat",
+            "https://cdsxmatch.u-strasbg.fr/QueryCat/QueryCat",
             data={
                 "mode": "mocfile",
                 "catName": resource_id,

--- a/python/mocpy/tests/test_moc.py
+++ b/python/mocpy/tests/test_moc.py
@@ -10,7 +10,7 @@ import regions
 from astropy.coordinates import Angle, Latitude, Longitude, SkyCoord, angular_separation
 from astropy.io import fits
 from astropy.io.votable import parse_single_table
-from astropy.table import QTable
+from astropy.table import QTable, Table
 
 from ..moc import MOC, WCS
 
@@ -320,6 +320,17 @@ def test_from_ivorn():
 
     with pytest.warns(UserWarning, match="This MOC is empty.*"):
         MOC.from_ivorn("abc")
+
+
+def test_query_vizier():
+    moc = MOC.from_cone(
+        Longitude(0 * u.deg),
+        Latitude(0 * u.deg),
+        radius=Angle(0.5, "arcmin"),
+        max_depth=8,
+    )
+    catalog = moc.query_vizier_table("I/305/out")
+    assert isinstance(catalog, Table)
 
 
 def test_moc_from_fits():


### PR DESCRIPTION
This PR does two things:

- change url of xmatch call to https (for use in pyodide)
- add a test for `query_vizier_table` (currently failing, the service is not returning votables)

question: should we change this call to use qat2s ?