### PR TITLE
ci: run remote tests only when needed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
            pip install maturin==1.12.4
            maturin develop --release
            pip install .[dev,plots]
-           python -m pytest python/mocpy/tests/
+           python -m pytest python/mocpy/tests/ --run-remote
          done
 
   test-macos-wheels:

--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ To run the tests, do:
 pip install .[dev]
 python -m pytest
 ```
+
+The tests that require to download remote data from external servers don't run by
+default. To execute them, do:
+
+```sh
+python -m pytest --run-remote
+```
+
 To check that the documentation builds. Make sure you have pandoc
 (https://pandoc.org/installing.html) and do:
 

--- a/conftest.py
+++ b/conftest.py
@@ -6,3 +6,25 @@ try:
     mpl.use("Agg")
 except ImportError:
     pass
+
+import pytest
+
+
+def pytest_addoption(parser):
+    """Add a custom CLI option run all tests including those marked as remote."""
+    parser.addoption(
+        "--run-remote",
+        action="store_true",
+        default=False,
+        help="Run all tests regardless of markers",
+    )
+
+
+# function executed right after test items collected but before test run
+def pytest_collection_modifyitems(config, items):
+    """Add option to run remote_data tests or not."""
+    if not config.getoption("-m"):
+        skip_me = pytest.mark.skip(reason="use `-m remote_data` to run this test")
+        for item in items:
+            if "remote_data" in item.keywords and not config.getoption("--run-remote"):
+                item.add_marker(skip_me)

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -53,7 +53,7 @@ Once your environment is set up and activated you can run the tests
 
 To run the automated tests and the docstring examples, go to the repo folder and type::
 
-    python -m pytest -v python/mocpy
+    python -m pytest -v
 
 To run the tests with coverage report locally::
 
@@ -61,6 +61,10 @@ To run the tests with coverage report locally::
 
 You also can have a html output of the coverage with the flag ``--cov-report=html``.
 This will generate an ``htmlcov`` folder where all the static html files can be found.
+
+Some tests which require remote data download are skipped by default. To run them, do::
+
+    python -m pytest --run-remote
 
 To be sure that your modifications didn't break the notebooks, do::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,5 +148,8 @@ convention = "numpy"  # Accepts: "google", "numpy", or "pep257"
 [tool.pytest.ini_options]
 addopts = "--doctest-modules"
 doctest_optionflags = "NORMALIZE_WHITESPACE"
+markers = [
+    "remote_data: marks tests that require to download a file from a remote server",
+]
 testpaths = ["python", "docs/examples/user_documentation.rst"]
 

--- a/python/mocpy/tests/test_moc.py
+++ b/python/mocpy/tests/test_moc.py
@@ -294,6 +294,7 @@ def test_from_polygons():
     assert list_mocs == list_mocs_no_skycoord
 
 
+@pytest.mark.remote_data
 def test_from_vizier():
     # deprecated nside should still work (nside=8 means order=3)
     with pytest.warns(
@@ -888,12 +889,14 @@ def test_neighbours(mocs):
     assert moc2 == mocs["moc2"]
 
 
+@pytest.mark.remote_data
 def test_query_simbad():
     moc = MOC.from_string("9/0")
     table = moc.query_simbad(select=["main_id", "main_type", "ra", "dec"])
     assert len(table) >= 10  # there are 13 results now but SIMBAD could be updated
 
 
+@pytest.mark.remote_data
 def test_query_vizier_table():
     moc = MOC.new_empty(max_depth=0).complement()
     table = moc.query_vizier_table("J/A+A/481/593/table1", max_rows=None)
@@ -901,6 +904,7 @@ def test_query_vizier_table():
     assert isinstance(table, Table)
 
 
+@pytest.mark.remote_data
 def test_query_vizier_table_exceptions():
     moc = MOC.new_empty(max_depth=0).complement()
     # overflow
@@ -912,6 +916,7 @@ def test_query_vizier_table_exceptions():
         table = moc.query_vizier_table("J/A+A/481/593/table1", output_format="blabla")
 
 
+@pytest.mark.remote_data
 def test_output_formats():
     # default astropy table tested in other tests
     # csv


### PR DESCRIPTION
this adds a pytest marker remote_data

and a CLI option --run-remote